### PR TITLE
fix platform crash when market place is down

### DIFF
--- a/src/Controller/DashboardPlugins/MelisCoreDashboardBubbleUpdatesPlugin.php
+++ b/src/Controller/DashboardPlugins/MelisCoreDashboardBubbleUpdatesPlugin.php
@@ -34,6 +34,13 @@ class MelisCoreDashboardBubbleUpdatesPlugin extends MelisCoreDashboardTemplating
 
     public function getUpdates()
     {
+        $melisMarketPlaceController = new \MelisMarketPlace\Controller\MelisMarketPlaceController();
+        if(!$melisMarketPlaceController->isMarketplaceAccessible()){
+            return new JsonModel([
+                'data' => [],
+                'count' => 0
+            ]);
+        }
         $moduleService = $this->getServiceManager()->get('MelisAssetManagerModulesService');
         $requestJsonUrl = $this->getMelisPackagistServer() . '/get-packages/page/1/search//item_per_page/0/order/asc/order_by//status/2/group/';
         $serverPackages = [];


### PR DESCRIPTION
i've added a check of accessiblity to marketplace server if the server didn't responde in 20 sec there i added some error handling to prevent the timeout base on changes done in the module melis-marketplace PR #15