### PR TITLE
Add explicit nullable param types (PHP 8.4 deprecation)

### DIFF
--- a/src/Factory/MelisAbstractFactory.php
+++ b/src/Factory/MelisAbstractFactory.php
@@ -67,7 +67,7 @@ class MelisAbstractFactory implements AbstractFactoryInterface
      * @param  null|array         $options
      * @return object
      */
-    public function __invoke(ContainerInterface $container, $requestedName, array $options = null)
+    public function __invoke(ContainerInterface $container, $requestedName, ?array $options = null)
     {
         // Requested class instance
         $instance = new $requestedName();

--- a/src/Form/View/Helper/MelisFieldCollection.php
+++ b/src/Form/View/Helper/MelisFieldCollection.php
@@ -10,7 +10,7 @@ class MelisFieldCollection extends FormCollection
     protected $shouldWrap = false;
     protected $defaultElementHelper = 'MelisFieldRow';
 
-    public function __invoke(ElementInterface $element = null, $wrap = false)
+    public function __invoke(?ElementInterface $element = null, $wrap = false)
     {
         $wrap = $this->shouldWrap;
 

--- a/src/Model/Hydrator/MelisUser.php
+++ b/src/Model/Hydrator/MelisUser.php
@@ -39,7 +39,7 @@ class MelisUser
         return $this->unfilteredDataCount;
     }
 
-    public function setUnfilteredDataCount(int $count = null)
+    public function setUnfilteredDataCount(?int $count = null)
     {
         $this->unfilteredDataCount = $count;
     }


### PR DESCRIPTION
## What

PHP 8.4 deprecates **implicitly nullable parameters** (`Type $x = null`). This makes
them explicit (`?Type $x = null`) in `src/`.

| File | Change |
|------|--------|
| `src/Model/Hydrator/MelisUser.php:42` | `int $count = null` → `?int $count = null` |
| `src/Factory/MelisAbstractFactory.php` | `array $options = null` → `?array $options = null` |
| `src/Form/View/Helper/MelisFieldCollection.php` | `ElementInterface $element = null` → `?ElementInterface $element = null` |

## Safety

**Behaviour-preserving**: PHP already treats `Type $x = null` as nullable, so adding
`?` changes nothing at runtime — it only silences the 8.4 deprecation. Generated with
PHP-CS-Fixer (`nullable_type_declaration_for_default_null_value`), `php -l` clean.

## Context

Reference PR for the PHP 8.4 support effort (#24). The same one-line recipe applies
to the other modules; this shows the expected (tiny, safe) diff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)