### PR TITLE
Unpin laminas-servicemanager to allow PHP 8.4 (3.24.x)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -45,7 +45,7 @@
 		"laminas/laminas-mvc-i18n": "^1.8",
 		"laminas/laminas-db": "^2.19",
 		"laminas/laminas-authentication": "^2.16",
-		"laminas/laminas-servicemanager": "3.22.1",
+		"laminas/laminas-servicemanager": "^3.22.1",
 		"laminas/laminas-mail": "^2.25",
 		"laminas/laminas-mime": "^2.12",
 		"laminas/laminas-inputfilter": "^2.28",


### PR DESCRIPTION
## What

`laminas/laminas-servicemanager` is pinned to the **exact** version `3.22.1`, which
requires `~8.1 || ~8.2 || ~8.3` — so it **blocks PHP 8.4** (it's the dependency that
fails `composer create-project` on 8.4).

`3.24.0` stays in the **3.x** line and supports 8.4 (`~8.2 || ~8.3 || ~8.4 || ~8.5`).
This loosens the exact pin to a caret range so the resolver can pick it:

```diff
- "laminas/laminas-servicemanager": "3.22.1",
+ "laminas/laminas-servicemanager": "^3.22.1",
```

Staying in 3.x avoids the BC breaks of servicemanager 4.x.

## Notes / needs validation

- **Run the test suite** — this was an exact pin, presumably for a reason; please
  confirm 3.23/3.24 don't regress.
- The platform **skeleton lock** should be regenerated (`composer update
  laminas/laminas-servicemanager`) so installs actually pick up the new version.
- A transitive `laminas/laminas-serializer 2.17.0` also caps at 8.3; it should resolve
  to an 8.4-compatible release once the tree is updated — worth verifying.

Part of the PHP 8.4 support effort (#24). Companion to the explicit-nullable-types PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)