### PR TITLE
Allow laminas-serializer ^3 for PHP 8.4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -56,7 +56,7 @@
 		"symfony/var-dumper": "^6.4",
 		"laminas/laminas-developer-tools": "^2.8",
 		"laminas/laminas-development-mode": "^3.12",
-		"laminas/laminas-serializer": "2.17",
+		"laminas/laminas-serializer": "^2.17 || ^3.0",
 		"laminas/laminas-paginator": "^2.18",
 		"symfony/service-contracts": "2.5.0",
 		"psr/container": "1.1.1",


### PR DESCRIPTION
Companion to #26. `laminas-serializer` was pinned to `2.17` (caps at PHP 8.3); the 3.x line supports 8.4/8.5. Loosen to `^2.17 || ^3.0`. Needs a test run. See #24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)