### PR TITLE
Drop deprecated ReflectionProperty::setAccessible() calls (PHP 8.5)

### DIFF
--- a/src/Service/MelisCoreToolService.php
+++ b/src/Service/MelisCoreToolService.php
@@ -229,10 +229,11 @@ class MelisCoreToolService extends MelisServiceManager implements MelisCoreToolS
         $renderer = $this->getServiceManager()->get('Laminas\View\Renderer\RendererInterface');
         $html = new \Laminas\Mime\Part($renderer->render($viewModel));
 
-        // since it will return an object with private properties, change the accessibility so we can get the content data we want.
+        // Read the private "content" property via reflection. ReflectionProperty::getValue()
+        // reads private/protected properties directly since PHP 8.1, so setAccessible() is a
+        // no-op (and deprecated on 8.5) — omitted.
         $reflection = new ReflectionClass($html);
         $property = $reflection->getProperty('content');
-        $property->setAccessible(true);
 
         $content = $property->getValue($html);
 

--- a/src/Service/MelisCoreTranslationService.php
+++ b/src/Service/MelisCoreTranslationService.php
@@ -62,10 +62,11 @@ class MelisCoreTranslationService extends Translator implements MelisCoreTransla
         $translation = $translator->getTranslator();
         $messages = array();
 
-        // process to access the private properties of translation service
+        // Access the private "files" property. ReflectionProperty::getValue() reads
+        // private/protected properties directly since PHP 8.1, so setAccessible() is a
+        // no-op (and deprecated on 8.5) — omitted.
         $reflector = new \ReflectionObject($translation);
         $property = $reflector->getProperty('files');
-        $property->setAccessible(true);
         $files = (array)$property->getValue($translation);
 
         if($files) {


### PR DESCRIPTION
## Problem
`ReflectionProperty::setAccessible()` is **deprecated on PHP 8.5** ("no effect since PHP 8.1"). The notices show up in the back-office on 8.5.

## Fix
Since PHP 8.1, `ReflectionProperty::getValue()`/`setValue()` read private/protected properties directly, so `setAccessible(true)` is already a no-op. This package requires `^8.1`, so the calls are removed with **no behaviour change**:

- `src/Service/MelisCoreToolService.php` — reading the private `content` of a `Laminas\Mime\Part`.
- `src/Service/MelisCoreTranslationService.php` — reading the translator's private `files`.

## Verification
- `php -l` clean on PHP **8.1** and **8.5**.
- `getValue()` behaviour is identical on all supported versions (8.1+); only the deprecated, effect-less call is removed.

## Context
Found while bringing Melis up on PHP 8.5 end-to-end (full install reached the working back-office). Part of the 8.5 effort tracked in #28; see also melisplatform/melis-installer#23 and melisplatform/melis-docker#9.

🤖 Generated with [Claude Code](https://claude.com/claude-code)